### PR TITLE
INTERLOK-2859

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ ext {
   slf4jVersion = '1.7.26'
   cxfVersion = '3.3.2'
   log4j2Version = '2.12.0'
-  istackVersion = '3.0.8'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {
@@ -91,23 +90,6 @@ dependencies {
   compile ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
   compile ("org.apache.cxf:cxf-rt-frontend-jaxws:$cxfVersion")
   compile ("org.apache.cxf:cxf-rt-transports-http:$cxfVersion")
-  compile ("org.apache.cxf:cxf-core:$cxfVersion") {
-    exclude group: 'org.glassfish.jaxb', module: 'jaxb-xjc'
-  }
-  compile ("org.glassfish.jaxb:jaxb-xjc:2.3.2") {
-    exclude group: 'com.sun.istack', module: 'istack-commons-tools'
-    exclude group: 'com.sun.istack', module: 'istack-commons-runtime'
-  }
-  compile ("com.sun.istack:istack-commons-runtime:$istackVersion") {
-    exclude group: 'junit', module: 'junit'
-    exclude group: 'org.testng', module: 'testng'
-    exclude group: 'com.beust', module: 'jcommander'
-  }
-  compile ("com.sun.istack:istack-commons-tools:$istackVersion") {
-    exclude group: 'junit', module: 'junit'
-    exclude group: 'org.testng', module: 'testng'
-    exclude group: 'com.beust', module: 'jcommander'
-  }
 
   compile ("org.slf4j:slf4j-api:$slf4jVersion")
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
   slf4jVersion = '1.7.26'
   cxfVersion = '3.3.2'
   log4j2Version = '2.12.0'
+  istackVersion = '3.0.8'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {
@@ -90,6 +91,23 @@ dependencies {
   compile ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
   compile ("org.apache.cxf:cxf-rt-frontend-jaxws:$cxfVersion")
   compile ("org.apache.cxf:cxf-rt-transports-http:$cxfVersion")
+  compile ("org.apache.cxf:cxf-core:$cxfVersion") {
+    exclude group: 'org.glassfish.jaxb', module: 'jaxb-xjc'
+  }
+  compile ("org.glassfish.jaxb:jaxb-xjc:2.3.2") {
+    exclude group: 'com.sun.istack', module: 'istack-commons-tools'
+    exclude group: 'com.sun.istack', module: 'istack-commons-runtime'
+  }
+  compile ("com.sun.istack:istack-commons-runtime:$istackVersion") {
+    exclude group: 'junit', module: 'junit'
+    exclude group: 'org.testng', module: 'testng'
+    exclude group: 'com.beust', module: 'jcommander'
+  }
+  compile ("com.sun.istack:istack-commons-tools:$istackVersion") {
+    exclude group: 'junit', module: 'junit'
+    exclude group: 'org.testng', module: 'testng'
+    exclude group: 'com.beust', module: 'jcommander'
+  }
 
   compile ("org.slf4j:slf4j-api:$slf4jVersion")
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '1.7.26'
-  cxfVersion = '3.2.7'
+  cxfVersion = '3.3.2'
   log4j2Version = '2.12.0'
 }
 

--- a/src/main/java/com/adaptris/core/services/cxf/ApacheSoapService.java
+++ b/src/main/java/com/adaptris/core/services/cxf/ApacheSoapService.java
@@ -75,6 +75,8 @@ public class ApacheSoapService extends ServiceImp {
   private static final String COM_SUN_CONNECT_TIMEOUT = "com.sun.xml.internal.ws.connect.timeout";
   private static final String COM_SUN_ALT_CONNECT_TIMEOUT = "com.sun.xml.internal.ws.request.timeout";
 
+  public static final String FALLBACK_TRANSFORMER_FACTORY_IMPL = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
+
   private String wsdlUrl;
   private String portName;
   private String serviceName;
@@ -102,6 +104,9 @@ public class ApacheSoapService extends ServiceImp {
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean perMessageDispatch;
+  @AdvancedConfig
+  @InputFieldDefault(value = "false")
+  private Boolean useFallbackTransformer;
 
   private transient Transformer transformer;
   private transient DispatchBuilder dispatchBuilder;
@@ -179,7 +184,12 @@ public class ApacheSoapService extends ServiceImp {
       } else {
         dispatchBuilder = new PersistentDispatcher(service);
       }
-      transformer = TransformerFactory.newInstance().newTransformer();
+      if (useJavaFallBackTransformer()) {
+        transformer = TransformerFactory.newInstance(FALLBACK_TRANSFORMER_FACTORY_IMPL, Thread.currentThread().getContextClassLoader())
+            .newTransformer();
+      } else {
+        transformer = TransformerFactory.newInstance().newTransformer();
+      }
     }
     catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
@@ -190,7 +200,9 @@ public class ApacheSoapService extends ServiceImp {
   public void doService(AdaptrisMessage msg) throws ServiceException {
     try (InputStream in = msg.getInputStream(); OutputStream out = msg.getOutputStream()) {
       Dispatch<Source> dispatcher = dispatchBuilder.build(msg);
-      StaxSource source = new StaxSource(XMLInputFactory.newInstance().createXMLStreamReader(in));
+      XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+      xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
+      StaxSource source = new StaxSource(xmlInputFactory.createXMLStreamReader(in));
       Source response = dispatcher.invoke(source);
       transformer.transform(response, new StreamResult(out));
     }
@@ -201,7 +213,6 @@ public class ApacheSoapService extends ServiceImp {
 
   @Override
   public void prepare() throws CoreException {}
-
 
   private Dispatch<Source> configureTimeouts(Dispatch<Source> d) {
     d.getRequestContext().put(COM_SUN_REQUEST_TIMEOUT, requestTimeout());
@@ -473,6 +484,32 @@ public class ApacheSoapService extends ServiceImp {
 
   private boolean perMessageDispatch() {
     return BooleanUtils.toBooleanDefaultIfNull(getPerMessageDispatch(), false);
+  }
+
+  public Boolean getUseFallbackTransformer() {
+    return useFallbackTransformer;
+  }
+
+  /**
+   * Specify whether to force the service to use the java fallback {@link TransformerFactory} rather than discovering one via the
+   * normal {@link TransformerFactory#newInstance()}.
+   * <p>
+   * Recent versions of {@code net.sf.saxon:Saxon-HE} (specificially 9.9.x onwards) have strong opinions and may omit namespace
+   * attributes when their identity transformer is used; this can result in something that is unexpected to downstream services. If
+   * this is the case for you, then set this to be true; and you will use the {@value #FALLBACK_TRANSFORMER_FACTORY_IMPL} as the
+   * transformer factory instead.
+   * </p>
+   * 
+   * @param b true to use {@value #FALLBACK_TRANSFORMER_FACTORY_IMPL} as the {@link TransformerFactory}; false if not explicitly
+   *        configured.
+   * @since 3.9.1
+   */
+  public void setUseFallbackTransformer(Boolean b) {
+    this.useFallbackTransformer = b;
+  }
+
+  private boolean useJavaFallBackTransformer() {
+    return BooleanUtils.toBooleanDefaultIfNull(getUseFallbackTransformer(), false);
   }
 
   @FunctionalInterface

--- a/src/main/java/com/adaptris/core/services/cxf/ApacheSoapService.java
+++ b/src/main/java/com/adaptris/core/services/cxf/ApacheSoapService.java
@@ -63,7 +63,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("apache-cxf-soap-service")
 @AdapterComponent
 @ComponentProfile(summary = "Execute a webservice using CXF", tag = "service,webservices,cxf")
-@DisplayOrder(order = {"wsdlUrl", "portName", "serviceName", "soapAction", "wsdlPortUrl", "username", "password"})
+@DisplayOrder(order = {"wsdlUrl", "portName", "serviceName", "soapAction", "endpointAddress", "wsdlPortUrl", "username", "password",
+    "useFallbackTransformer", "perMessageDispatch"})
 public class ApacheSoapService extends ServiceImp {
 
   private static final TimeInterval DEFAULT_REQUEST_TIMEOUT = new TimeInterval(50l, TimeUnit.SECONDS);
@@ -104,7 +105,6 @@ public class ApacheSoapService extends ServiceImp {
   @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean perMessageDispatch;
-  @AdvancedConfig
   @InputFieldDefault(value = "false")
   private Boolean useFallbackTransformer;
 

--- a/src/test/java/com/adaptris/core/services/cxf/ApacheSoapServiceTest.java
+++ b/src/test/java/com/adaptris/core/services/cxf/ApacheSoapServiceTest.java
@@ -143,6 +143,7 @@ public class ApacheSoapServiceTest extends ServiceCase {
     ApacheSoapService service = create();
     try {
       service.setPerMessageDispatch(true);
+      service.setUseFallbackTransformer(true);
       LifecycleHelper.initAndStart(service);
       service.doService(AdaptrisMessageFactory.getDefaultInstance().newMessage(ECHO_REQUEST));
       service.doService(msg);


### PR DESCRIPTION
- Had a delve into the Saxon Identity Transformer output properties; there's nothing obvious
- messed around with making the XmlFactory.newInstance namespace aware (it already is).
While it's obvious Saxon has opinions (and they're right most likely, once you get down to it); the "source" declares a namespace, but it hasn't been declared (since it would have been declared in the SOAP envelope); and the source starts at the `<soapenv:Body>`

- It might be a "you aren't using woodstox problem" so the the default XMLInputFactory isn't playing nice with Saxon...

So the end result is : 
- Add configuration to allow to use the fallback transformer
- Bump cxf to 3.3.2
