### PR TITLE
INTERLOK-2871 Add Metadata as HTTP headers to a SOAP request.

### DIFF
--- a/src/main/java/com/adaptris/core/services/cxf/MetadataToRequestHeaders.java
+++ b/src/main/java/com/adaptris/core/services/cxf/MetadataToRequestHeaders.java
@@ -1,0 +1,67 @@
+package com.adaptris.core.services.cxf;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.ws.Dispatch;
+import javax.xml.ws.handler.Handler;
+import javax.xml.ws.handler.MessageContext;
+
+import com.adaptris.core.MetadataElement;
+
+/**
+ * Handler implementation that just adds key-value pairs to the context request headers.
+ * 
+ */
+@FunctionalInterface
+public interface MetadataToRequestHeaders extends Handler {
+
+
+  @Override
+  default boolean handleFault(MessageContext context) {
+    return true;
+  }
+
+  @Override
+  default void close(MessageContext context) {
+    // Do nothing
+  }
+
+  static Map<String, List> getRequestHeaders(MessageContext context) {
+    Map<String, List> headers = (Map<String, List>) context.get(MessageContext.HTTP_REQUEST_HEADERS);
+    if (headers == null) {
+      headers = new HashMap<>();
+      context.put(MessageContext.HTTP_REQUEST_HEADERS, headers);
+    }
+    return headers;
+  }
+
+  static void register(Dispatch dispatch, MetadataToRequestHeaders handler) {
+    List<Handler> handlers = dispatch.getBinding().getHandlerChain();
+    if (handlers == null) {
+      handlers = Arrays.asList(handler);
+    } else {
+      handlers.add(handler);
+    }
+    dispatch.getBinding().setHandlerChain(handlers);
+  }
+
+  static void register(final Collection<MetadataElement> metadata, final Dispatch dispatch) {
+    register(dispatch,  (context) -> {
+      try {
+        Map<String, List> headers = getRequestHeaders(context);
+        for (MetadataElement e: metadata) {
+          headers.put(e.getKey(), Collections.singletonList(e.getValue()));
+        }
+      } catch (Exception ce) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+}

--- a/src/test/java/com/adaptris/core/services/cxf/MetadataToRequestHeadersTest.java
+++ b/src/test/java/com/adaptris/core/services/cxf/MetadataToRequestHeadersTest.java
@@ -1,0 +1,155 @@
+package com.adaptris.core.services.cxf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.ws.Dispatch;
+import javax.xml.ws.handler.Handler;
+import javax.xml.ws.handler.MessageContext;
+
+import org.apache.cxf.jaxws.DispatchImpl;
+import org.apache.cxf.jaxws.binding.http.HTTPBindingImpl;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.adaptris.core.MetadataElement;
+
+public class MetadataToRequestHeadersTest {
+
+  @Test
+  public void testGetRequestHeaders() {
+    MyMessageContext ctx = new MyMessageContext(false);
+    Map<String, List> h1 = MetadataToRequestHeaders.getRequestHeaders(ctx);
+    assertNotNull(h1);
+    assertFalse(h1 == ctx.httpHeaders);
+    MyMessageContext ctx2 = new MyMessageContext(true);
+    Map<String, List> h2 = MetadataToRequestHeaders.getRequestHeaders(ctx2);
+    assertNotNull(h2);
+    assertTrue(h2 == ctx2.httpHeaders);
+  }
+
+
+  @Test
+  public void testRegister_NoHandlerChain() {
+    Dispatch dispatch = Mockito.mock(DispatchImpl.class);
+    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Mockito.when(dispatch.getBinding()).thenReturn(binding);
+    Mockito.when(binding.getHandlerChain()).thenReturn(null);
+
+    MetadataToRequestHeaders.register(dispatch, (context) -> true);
+
+  }
+
+  @Test
+  public void testRegister_HandlerChain() {
+    List<Handler> list = new ArrayList<>();
+    Dispatch dispatch = Mockito.mock(DispatchImpl.class);
+    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Mockito.when(dispatch.getBinding()).thenReturn(binding);
+    Mockito.when(binding.getHandlerChain()).thenReturn(list);
+
+    MetadataToRequestHeaders.register(dispatch, (context) -> true);
+    assertEquals(1, list.size());
+  }
+
+  @Test
+  public void testHandleMessage() {
+    List<Handler> list = new ArrayList<>();
+    List<MetadataElement> elements = Arrays.asList(new MetadataElement("hello", "world"));
+
+    Dispatch dispatch = Mockito.mock(DispatchImpl.class);
+    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Mockito.when(dispatch.getBinding()).thenReturn(binding);
+    Mockito.when(binding.getHandlerChain()).thenReturn(list);
+
+    MetadataToRequestHeaders.register(elements, dispatch);
+
+    assertEquals(1, list.size());
+    MyMessageContext ctx = new MyMessageContext(true);
+
+    assertTrue(list.get(0).handleMessage(ctx));
+    assertTrue(ctx.httpHeaders.containsKey("hello"));
+  }
+
+  @Test
+  public void testHandleMessage_Failure() {
+    List<Handler> list = new ArrayList<>();
+    List<MetadataElement> elements = Arrays.asList(new BrokenMetadataElement("hello", "world"));
+
+    Dispatch dispatch = Mockito.mock(DispatchImpl.class);
+    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Mockito.when(dispatch.getBinding()).thenReturn(binding);
+    Mockito.when(binding.getHandlerChain()).thenReturn(list);
+
+    MetadataToRequestHeaders.register(elements, dispatch);
+
+    assertEquals(1, list.size());
+    MyMessageContext ctx = new MyMessageContext(true);
+
+    assertFalse(list.get(0).handleMessage(ctx));
+  }
+
+  @Test
+  public void testHandleFault() {
+    List<Handler> list = new ArrayList<>();
+    List<MetadataElement> elements = Arrays.asList(new MetadataElement("hello", "world"));
+
+    Dispatch dispatch = Mockito.mock(DispatchImpl.class);
+    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Mockito.when(dispatch.getBinding()).thenReturn(binding);
+    Mockito.when(binding.getHandlerChain()).thenReturn(list);
+
+    MetadataToRequestHeaders.register(elements, dispatch);
+
+    assertEquals(1, list.size());
+    MyMessageContext ctx = new MyMessageContext(true);
+
+    assertTrue(list.get(0).handleFault(ctx));
+  }
+
+
+  @SuppressWarnings("serial")
+  private class MyMessageContext extends HashMap<String, Object> implements MessageContext {
+
+    private Map<String, Scope> scopes = new HashMap<>();
+    private Map<String, List> httpHeaders = new HashMap<>();
+
+    public MyMessageContext(boolean withRequestHdrs) {
+      super();
+      if (withRequestHdrs) {
+        put(MessageContext.HTTP_REQUEST_HEADERS, httpHeaders);
+      }
+    }
+
+    @Override
+    public void setScope(String name, Scope scope) {
+      scopes.put(name, scope);
+    }
+
+    @Override
+    public Scope getScope(String name) {
+      return scopes.get(name);
+    }
+
+  }
+
+  @SuppressWarnings("serial")
+  private class BrokenMetadataElement extends MetadataElement {
+    public BrokenMetadataElement(String key, String value) {
+      super(key, value);
+    }
+
+    @Override
+    public String getValue() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/src/test/java/com/adaptris/core/services/cxf/SoapServiceTestbedDocumentTest.java
+++ b/src/test/java/com/adaptris/core/services/cxf/SoapServiceTestbedDocumentTest.java
@@ -11,6 +11,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.BaseCase;
 import com.adaptris.core.ServiceCase;
+import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.util.TimeInterval;
 
 public class SoapServiceTestbedDocumentTest extends BaseCase {
@@ -30,6 +31,18 @@ public class SoapServiceTestbedDocumentTest extends BaseCase {
     Assert.assertEquals("Mouse", val);
   }
   
+  public void testInvokeGetPerson_WithFilter() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(GET_PERSON_REQUEST);
+    ApacheSoapService service = create();
+    service.setMetadataFilter(new NoOpMetadataFilter());
+    ServiceCase.execute(service, msg);
+    Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new ByteArrayInputStream(msg.getPayload()));
+    String val = doc.getElementsByTagName("firstname").item(0).getTextContent();
+    Assert.assertEquals("Mickey", val);
+    val = doc.getElementsByTagName("surname").item(0).getTextContent();
+    Assert.assertEquals("Mouse", val);
+  }
+
   private ApacheSoapService create() {
     ApacheSoapService service = new ApacheSoapService();
     service.setWsdlUrl("http://testbed.adaptris.net/web-service-test/webservicetestrpc?wsdl");


### PR DESCRIPTION
Add a metadata handler that adds arbitrary HTTP headers.
Do we need to extend the marker interface LogicalHandler so we can use it with HTTPBindingImpl; it doesn't matter for the mocks, and the integration tests work.

```
<apache-cxf-soap-service>
...
  <metadata-filter class="no-op-metadata-filter"/>
</apache-cxf-soap-service>
```

Will send whatever METADATA that is present in the message to the endpoint