### PR TITLE
Feature/interlok 4477

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
@@ -31,7 +31,7 @@ ext {
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '2.0.17'
   mockitoVersion = '5.2.0'
-  cxfVersion = '3.5.10'
+  cxfVersion = '4.1.2'
 }
 
 
@@ -145,14 +145,14 @@ dependencies {
   api ("org.apache.cxf:cxf-rt-transports-http:$cxfVersion")
 
  if (JavaVersion.current().ordinal() >= JavaVersion.VERSION_1_9.ordinal()) {
-    api ("javax.xml.ws:jaxws-api:2.3.1")
-    api ("javax.jws:jsr181-api:1.0-MR1")
-    api ("jakarta.xml.bind:jakarta.xml.bind-api:2.3.2")
-    runtimeOnly ("org.glassfish.jaxb:jaxb-runtime:2.3.8")
-    runtimeOnly ("com.sun.xml.messaging.saaj:saaj-impl:1.5.1")
-    runtimeOnly ("javax.xml.soap:saaj-api:1.3.5")
-    runtimeOnly ("org.glassfish:javax.json:1.1.4")
-    runtimeOnly ("org.eclipse:yasson:1.0.1")
+    api ("jakarta.xml.ws:jakarta.xml.ws-api:4.0.2")
+    api ("jakarta.jws:jakarta.jws-api:3.0.0")
+    api ("jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
+    runtimeOnly ("org.glassfish.jaxb:jaxb-runtime:4.0.5")
+    runtimeOnly ("com.sun.xml.messaging.saaj:saaj-impl:3.0.4")
+    runtimeOnly ("jakarta.xml.soap:jakarta.xml.soap-api:3.0.2")
+    runtimeOnly ("org.glassfish:jakarta.json:2.0.1")
+    runtimeOnly ("org.eclipse:yasson:3.0.4")
   }
 
 

--- a/src/main/java/com/adaptris/core/services/cxf/ApacheSoapService.java
+++ b/src/main/java/com/adaptris/core/services/cxf/ApacheSoapService.java
@@ -14,9 +14,9 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.ws.BindingProvider;
-import javax.xml.ws.Dispatch;
-import javax.xml.ws.Service;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.Dispatch;
+import jakarta.xml.ws.Service;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;

--- a/src/main/java/com/adaptris/core/services/cxf/MetadataToRequestHeaders.java
+++ b/src/main/java/com/adaptris/core/services/cxf/MetadataToRequestHeaders.java
@@ -7,9 +7,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.ws.Dispatch;
-import javax.xml.ws.handler.Handler;
-import javax.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.Dispatch;
+import jakarta.xml.ws.handler.Handler;
+import jakarta.xml.ws.handler.MessageContext;
 
 import com.adaptris.core.MetadataElement;
 

--- a/src/test/java/com/adaptris/core/services/cxf/ApacheSoapServiceTest.java
+++ b/src/test/java/com/adaptris/core/services/cxf/ApacheSoapServiceTest.java
@@ -11,7 +11,7 @@ import java.io.ByteArrayInputStream;
 import java.util.concurrent.TimeUnit;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.ws.soap.SOAPFaultException;
+import jakarta.xml.ws.soap.SOAPFaultException;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/adaptris/core/services/cxf/DispatchConfigTest.java
+++ b/src/test/java/com/adaptris/core/services/cxf/DispatchConfigTest.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.xml.transform.Source;
-import javax.xml.ws.Dispatch;
+import jakarta.xml.ws.Dispatch;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/src/test/java/com/adaptris/core/services/cxf/MetadataToRequestHeadersTest.java
+++ b/src/test/java/com/adaptris/core/services/cxf/MetadataToRequestHeadersTest.java
@@ -11,12 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.ws.Dispatch;
-import javax.xml.ws.handler.Handler;
-import javax.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.Binding;
+import jakarta.xml.ws.Dispatch;
+import jakarta.xml.ws.handler.Handler;
+import jakarta.xml.ws.handler.MessageContext;
 
-import org.apache.cxf.jaxws.DispatchImpl;
-import org.apache.cxf.jaxws.binding.http.HTTPBindingImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -38,8 +37,8 @@ public class MetadataToRequestHeadersTest {
 
   @Test
   public void testRegister_NoHandlerChain() {
-    Dispatch<?> dispatch = Mockito.mock(DispatchImpl.class);
-    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Dispatch<?> dispatch = Mockito.mock(Dispatch.class);
+    Binding binding = Mockito.mock(Binding.class);
     Mockito.when(dispatch.getBinding()).thenReturn(binding);
     Mockito.when(binding.getHandlerChain()).thenReturn(null);
 
@@ -50,8 +49,8 @@ public class MetadataToRequestHeadersTest {
   @Test
   public void testRegister_HandlerChain() {
     List<Handler> list = new ArrayList<>();
-    Dispatch<?> dispatch = Mockito.mock(DispatchImpl.class);
-    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Dispatch<?> dispatch = Mockito.mock(Dispatch.class);
+    Binding binding = Mockito.mock(Binding.class);
     Mockito.when(dispatch.getBinding()).thenReturn(binding);
     Mockito.when(binding.getHandlerChain()).thenReturn(list);
 
@@ -64,8 +63,8 @@ public class MetadataToRequestHeadersTest {
     List<Handler> list = new ArrayList<>();
     List<MetadataElement> elements = Arrays.asList(new MetadataElement("hello", "world"));
 
-    Dispatch<?> dispatch = Mockito.mock(DispatchImpl.class);
-    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Dispatch<?> dispatch = Mockito.mock(Dispatch.class);
+    Binding binding = Mockito.mock(Binding.class);
     Mockito.when(dispatch.getBinding()).thenReturn(binding);
     Mockito.when(binding.getHandlerChain()).thenReturn(list);
 
@@ -83,8 +82,8 @@ public class MetadataToRequestHeadersTest {
     List<Handler> list = new ArrayList<>();
     List<MetadataElement> elements = Arrays.asList(new BrokenMetadataElement("hello", "world"));
 
-    Dispatch<?> dispatch = Mockito.mock(DispatchImpl.class);
-    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Dispatch<?> dispatch = Mockito.mock(Dispatch.class);
+    Binding binding = Mockito.mock(Binding.class);
     Mockito.when(dispatch.getBinding()).thenReturn(binding);
     Mockito.when(binding.getHandlerChain()).thenReturn(list);
 
@@ -101,8 +100,8 @@ public class MetadataToRequestHeadersTest {
     List<Handler> list = new ArrayList<>();
     List<MetadataElement> elements = Arrays.asList(new MetadataElement("hello", "world"));
 
-    Dispatch<?> dispatch = Mockito.mock(DispatchImpl.class);
-    HTTPBindingImpl binding = Mockito.mock(HTTPBindingImpl.class);
+    Dispatch<?> dispatch = Mockito.mock(Dispatch.class);
+    Binding binding = Mockito.mock(Binding.class);
     Mockito.when(dispatch.getBinding()).thenReturn(binding);
     Mockito.when(binding.getHandlerChain()).thenReturn(list);
 


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


